### PR TITLE
Addition of CuPy as an Accelerated Computing Option

### DIFF
--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -66,10 +66,11 @@ class Conf(_config.ConfigNamespace):
 
     use_cuda = _config.ConfigItem(True, 'Use cuda for FFTs on GPU (assuming it' +
             'is available)?')
-    use_cupy = _config.ConfigItem(True, 'Use cupy for FFTs on GPU (assuming it' +
-            'is available)?')
     use_opencl = _config.ConfigItem(True, 'Use OpenCL for FFTs on GPU (assuming it' +
             'is available)?')
+    use_cupy = _config.ConfigItem(True, 'Use cupy for FFTs on GPU (assuming it' +
+            'is available)?')
+    
     use_numexpr = _config.ConfigItem(True, 'Use NumExpr to accelerate array math (assuming it' +
             'is available)?')
 

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -66,6 +66,8 @@ class Conf(_config.ConfigNamespace):
 
     use_cuda = _config.ConfigItem(True, 'Use cuda for FFTs on GPU (assuming it' +
             'is available)?')
+    use_cupy = _config.ConfigItem(True, 'Use cupy for FFTs on GPU (assuming it' +
+            'is available)?')
     use_opencl = _config.ConfigItem(True, 'Use OpenCL for FFTs on GPU (assuming it' +
             'is available)?')
     use_numexpr = _config.ConfigItem(True, 'Use NumExpr to accelerate array math (assuming it' +

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -103,7 +103,7 @@ def _complex():
 def _r(x, y):
     """ Function to speed up computing the radius given x and y, using Numexpr if available
     Otherwise defaults to numpy. """
-    if _USE_NUMEXPR:
+    if _USE_NUMEXPR and not _USE_CUPY:
         return ne.evaluate("sqrt(x**2+y**2)")
     else:
         return np.sqrt(x ** 2 + y ** 2)

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -332,7 +332,7 @@ def fft_2d(wavefront, forward=True, normalization=None, fftshift=True):
         # See comment above in this function.
         wavefront = _fftshift(wavefront)
         
-    print('\t\t', normalization, wavefront.dtype, isinstance(wavefront, cp.ndarray))
+#     print('\t\t', normalization, wavefront.dtype, isinstance(wavefront, cp.ndarray))
     wavefront *= normalization
     t3 = time.time()
     _log.debug("    FFT_2D: FFT in {:3f} s, full function  in {:.3f} s".format(t2-t1, t3-t0))

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -11,7 +11,6 @@ import time
 import logging
 _log = logging.getLogger('poppy')
 
-
 try:
     # try to import FFTW to see if it is available
     import pyfftw

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -728,9 +728,9 @@ class SegmentedDeformableMirror(ABC):
 
         if segnum not in self.segmentlist:
             raise ValueError("Segment {} is not present for this DM instance.".format(segnum))
-        self._surface[segnum] = [piston.to(u.meter).value,
-                                 tip.to(u.radian).value,
-                                 tilt.to(u.radian).value]
+        self._surface[segnum] = np.array([piston.to(u.meter).value,
+                                          tip.to(u.radian).value,
+                                          tilt.to(u.radian).value])
 
     def _setup_arrays(self, npix, pixelscale, wave=None):
         """ Set up the arrays to compute an OPD into.

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -1,7 +1,6 @@
 # Code for modeling deformable mirrors
 # By Neil Zimmerman based on Marshall's dms.py in the gpipsfs repo
 
-import numpy as np
 import matplotlib.pyplot as plt
 import scipy.ndimage.interpolation
 import scipy.signal
@@ -10,6 +9,14 @@ import astropy.units as u
 from abc import ABC, abstractmethod
 
 from . import utils, accel_math, poppy_core, optics
+
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+    import cupyx.scipy.ndimage as ndimage
+else:
+    import numpy as np
+    import scipy.ndimage as ndimage
 
 import logging
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1066,13 +1066,13 @@ class FresnelWavefront(BaseWavefront):
 
         # get the fpm phasor either using numexpr or numpy
         scale = 2. * np.pi / self.wavelength.to(u.meter).value
-        if accel_math._USE_NUMEXPR:
+        if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
             _log.debug("Calculating FPM phasor from numexpr.")
             trans = optic.get_transmission(self)
             opd = optic.get_opd(self)
             fpm_phasor = ne.evaluate("trans * exp(1.j * opd * scale)")
         else:
-            _log.debug("numexpr not available, calculating FPM phasor with numpy.")
+            _log.debug("Calculating FPM phasor with numpy/cupy.")
             fpm_phasor = optic.get_transmission(self) * np.exp(1.j * optic.get_opd(self) * scale)
         
         nfpm = fpm_phasor.shape[0]

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -4,9 +4,14 @@
 #  at subpixel precision. (or at least reasonably proper; no
 #  guarantees for utter mathematical exactness at machine precision.)
 
-import numpy as np
-
 from . import accel_math
+
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+else:
+    import numpy as np
+
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
 
@@ -34,8 +39,8 @@ def _arc(x, y0, y1, r):
     is traversed clockwise then the area is negative, otherwise it is
     positive.
     """
-    with np.errstate(divide='ignore'):
-        if accel_math._USE_NUMEXPR:
+    with numpy.errstate(divide='ignore'):
+        if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
             return ne.evaluate("0.5 * r**2 * (arctan(y1/x) - arctan(y0/x))")
         else:
             return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))

--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -54,11 +54,18 @@
 
 __all__ = ['MatrixFourierTransform']
 
-import numpy as np
 from . import conf
 from . import accel_math
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
+    
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+    rnd = numpy.round
+else:
+    import numpy as np
+    rnd = np.round
 
 import logging
 _log = logging.getLogger('poppy')
@@ -121,7 +128,7 @@ def matrix_dft(plane, nlamD, npix,
         (offsetY, offsetX).
     """
 
-    if accel_math._USE_NUMEXPR:
+    if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
         return matrix_dft_numexpr(plane, nlamD, npix,
                offset=offset, inverse=inverse, centering=centering)
     float = accel_math._float()

--- a/poppy/misc.py
+++ b/poppy/misc.py
@@ -4,10 +4,20 @@
 #
 ############################################################################
 
-import numpy as np
-import scipy
 import matplotlib.pyplot as plt
 
+from . import accel_math
+
+if accel_math._USE_NUMEXPR:
+    import numexpr as ne
+
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+    from cupyx.scipy.special import j1
+else:
+    import numpy as np
+    from scipy.special import j1
 
 _RADtoARCSEC = 180.*60*60/np.pi  # ~ 206265
 _ARCSECtoRAD = np.pi/(180.*60*60)
@@ -48,7 +58,8 @@ def airy_1d(diameter=1.0, wavelength=1e-6, length=512, pixelscale=0.010,
     # pedantically avoid divide by 0 by setting 0s to minimum nonzero number
     v[v == 0] = np.finfo(v.dtype).eps
 
-    airy = 1./(1-e**2)**2 * ((2*scipy.special.jn(1, v) - e*2*scipy.special.jn(1, e*v))/v)**2
+#     airy = 1./(1-e**2)**2 * ((2*scipy.special.jn(1, v) - e*2*scipy.special.jn(1, e*v))/v)**2
+    airy = 1./(1-e**2)**2 * ((2*j1(v) - e*2*j1(e*v))/v)**2
     # see e.g. Schroeder, Astronomical Optics, 2nd ed. page 248
 
     if plot:
@@ -96,7 +107,8 @@ def airy_2d(diameter=1.0, wavelength=1e-6, shape=(512, 512), pixelscale=0.010,
     # pedantically avoid divide by 0 by setting 0s to minimum nonzero number
     v[v == 0] = np.finfo(v.dtype).eps
 
-    airy = 1./(1-e**2)**2 * ((2*scipy.special.jn(1, v) - e*2*scipy.special.jn(1, e*v))/v)**2
+#     airy = 1./(1-e**2)**2 * ((2*scipy.special.jn(1, v) - e*2*scipy.special.jn(1, e*v))/v)**2
+    airy = 1./(1-e**2)**2 * ((2*j1(v) - e*2*j1(e*v))/v)**2
     # see e.g. Schroeder, Astronomical Optics, 2nd ed. page 248
     return airy
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1607,7 +1607,7 @@ class RectangleAperture(AnalyticOpticalElement):
             name = "Rectangle, size= {s.width:.1f} wide * {s.height:.1f} high".format(s=self)
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, rotation=rotation, **kwargs)
         # for creating input wavefronts:
-        self.pupil_diam = np.sqrt(self.height ** 2 + self.width ** 2)
+        self.pupil_diam = numpy.sqrt(self.height ** 2 + self.width ** 2)
 
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
@@ -1757,18 +1757,18 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
                  support_offset_x=0.0, support_offset_y=0.0, **kwargs):
         SecondaryObscuration.__init__(self, n_supports=len(support_angle), **kwargs)
 
-        self.support_angle = np.asarray(support_angle)
+        self.support_angle = numpy.asarray(support_angle)
 
-        if np.isscalar(support_width.value):
-            support_width = np.zeros(len(support_angle)) + support_width
+        if numpy.isscalar(support_width.value):
+            support_width = numpy.zeros(len(support_angle)) + support_width
         self.support_width = support_width
 
-        if np.isscalar(support_offset_x):
-            support_offset_x = np.zeros(len(support_angle)) + support_offset_x
+        if numpy.isscalar(support_offset_x):
+            support_offset_x = numpy.zeros(len(support_angle)) + support_offset_x
         self.support_offset_x = support_offset_x
 
-        if np.isscalar(support_offset_y):
-            support_offset_y = np.zeros(len(support_angle)) + support_offset_y
+        if numpy.isscalar(support_offset_y):
+            support_offset_y = numpy.zeros(len(support_angle)) + support_offset_y
         self.support_offset_y = support_offset_y
 
     def get_transmission(self, wave):
@@ -1897,7 +1897,7 @@ class GaussianAperture(AnalyticOpticalElement):
         elif w is not None:
             self.w = w
         elif fwhm is not None:
-            self.w = fwhm / (2 * np.sqrt(np.log(2)))
+            self.w = fwhm / (2 * numpy.sqrt(numpy.log(2)))
 
         if pupil_diam is None:
             pupil_diam = 3 * self.fwhm  # for creating input wavefronts
@@ -1908,7 +1908,7 @@ class GaussianAperture(AnalyticOpticalElement):
 
     @property
     def fwhm(self):
-        return self.w * (2 * np.sqrt(np.log(2)))
+        return self.w * (2 * numpy.sqrt(numpy.log(2)))
 
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the aperture.

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -15,6 +15,14 @@ from .poppy_core import OpticalElement, Wavefront, BaseWavefront, PlaneType, _RA
 from .accel_math import _exp, _r, _float, _complex
 from . import geometry
 
+from importlib import reload
+
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+else:
+    import numpy as np
+
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
 
@@ -119,7 +127,7 @@ class AnalyticOpticalElement(OpticalElement):
             wavelength = wave
         scale = 2. * np.pi / wavelength.to(u.meter).value
 
-        if accel_math._USE_NUMEXPR:
+        if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
             trans = self.get_transmission(wave)
             opd = self.get_opd(wave)
             # we first multiply the two scalars, for a slight performance gain

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1216,7 +1216,7 @@ class HexagonAperture(AnalyticOpticalElement):
         elif diameter is not None:
             self.side = diameter / 2
         else:
-            self.side = flattoflat / np.sqrt(3.)
+            self.side = flattoflat / numpy.sqrt(3.)
 
         self.pupil_diam = 2 * self.side  # for creating input wavefronts
         self._default_display_size = 3 * self.side
@@ -2062,7 +2062,6 @@ class CompoundAnalyticOptic(AnalyticOpticalElement):
                     else:
                         self._default_display_size = optic._default_display_size
                 if hasattr(optic, 'pupil_diam'):
-                    print(optic.pupil_diam)
                     if not hasattr(self, 'pupil_diam'):
                         self.pupil_diam = optic.pupil_diam
                     else:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -148,6 +148,8 @@ class AnalyticOpticalElement(OpticalElement):
                 return np.asarray(result, _complex())
 
         else:
+            import cupy
+            print(isinstance(self.get_opd(wave), cupy.ndarray), isinstance(self.get_transmission(wave), cupy.ndarray))
             return self.get_transmission(wave) * np.exp(1.j * self.get_opd(wave) * scale)
 
     @utils.quantity_input(wavelength=u.meter)
@@ -1431,8 +1433,8 @@ class MultiHexagonAperture(MultiSegmentAperture):
         elif side is not None:
             self.side = side
         else:
-            self.side = flattoflat / np.sqrt(3.)
-        self.flattoflat = self.side * np.sqrt(3)
+            self.side = flattoflat / numpy.sqrt(3.)
+        self.flattoflat = self.side * numpy.sqrt(3)
 
         super().__init__(name=name, segment_size=self.flattoflat,
                          gap=gap, rings=rings, segmentlist=segmentlist, center=center, **kwargs)
@@ -2062,6 +2064,7 @@ class CompoundAnalyticOptic(AnalyticOpticalElement):
                     else:
                         self._default_display_size = optic._default_display_size
                 if hasattr(optic, 'pupil_diam'):
+                    print(optic.pupil_diam)
                     if not hasattr(self, 'pupil_diam'):
                         self.pupil_diam = optic.pupil_diam
                     else:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -148,8 +148,6 @@ class AnalyticOpticalElement(OpticalElement):
                 return np.asarray(result, _complex())
 
         else:
-            import cupy
-            print(isinstance(self.get_opd(wave), cupy.ndarray), isinstance(self.get_transmission(wave), cupy.ndarray))
             return self.get_transmission(wave) * np.exp(1.j * self.get_opd(wave) * scale)
 
     @utils.quantity_input(wavelength=u.meter)

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -336,9 +336,12 @@ class AnalyticOpticalElement(OpticalElement):
             else:
                 y -= float(self.shift_y)
         if hasattr(self, "rotation"):
-            angle = np.deg2rad(self.rotation)
-            xp = np.cos(angle) * x + np.sin(angle) * y
-            yp = -np.sin(angle) * x + np.cos(angle) * y
+#             angle = np.deg2rad(self.rotation)
+#             xp = np.cos(angle) * x + np.sin(angle) * y
+#             yp = -np.sin(angle) * x + np.cos(angle) * y
+            angle = numpy.deg2rad(self.rotation)
+            xp = numpy.cos(angle).value * x + numpy.sin(angle).value * y
+            yp = -numpy.sin(angle).value * x + numpy.cos(angle).value * y
             x = xp
             y = yp
         # inclination around X axis rescales Y, and vice versa:

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -145,8 +145,9 @@ class BaseWavefront(ABC):
         
         '''MY CHANGE: Added a GPU wavefront attribute'''
         if accel_math._USE_CUPY:
-            import cupy as cp
             self.wavefront_gpu = cp.array(self.wavefront)
+        else: 
+            self.wavefront_gpu = None
         
 
     def __str__(self):
@@ -160,7 +161,7 @@ class BaseWavefront(ABC):
         """Return a copy of the wavefront as a different object."""
         return copy.deepcopy(self)
 
-    def normalize(self):
+    def normalize(self): ###########
         """Set this wavefront's total intensity to 1 """
         sqrt_ti = np.sqrt(self.total_intensity)
         if sqrt_ti == 0:
@@ -168,7 +169,11 @@ class BaseWavefront(ABC):
         elif not np.isfinite(sqrt_ti):
             _log.warning("Total intensity is NaN or Inf when trying to normalize the wavefront. Cannot normalize.")
         else:
-            self.wavefront /= sqrt_ti
+#             self.wavefront /= sqrt_ti
+            if self.wavefront_gpu is not None:
+                self.wavefront_gpu /= sqrt_ti
+            else:
+                self.wavefront /= sqrt_ti
 
     def __imul__(self, optic):
         """Multiply a Wavefront by an OpticalElement or scalar"""
@@ -177,6 +182,8 @@ class BaseWavefront(ABC):
             # but instead via forcing a call to rotate() or invert() in propagate_to...
         elif np.isscalar(optic):
             self.wavefront *= optic  # it's just a scalar
+            if self.wavefront_gpu is not None:
+                self.wavefront_gpu *= optic  # it's just a scalar
             self.history.append("Multiplied WF by scalar value " + str(optic))
             return self
         elif not isinstance(optic, OpticalElement):
@@ -194,7 +201,7 @@ class BaseWavefront(ABC):
                 phasor.shape, self.wavefront.shape)
             
 #         self.wavefront *= phasor
-        if accel_math._USE_CUPY:
+        if self.wavefront_gpu is not None:
             self.wavefront_gpu *= cp.array(phasor)
         else:
             self.wavefront *= phasor
@@ -420,7 +427,7 @@ class BaseWavefront(ABC):
         """
         if scale is None:
             scale = 'log' if self.planetype == PlaneType.image else 'linear'
-
+        
         if row is None:
             row = self.current_plane_index
 
@@ -705,7 +712,7 @@ class BaseWavefront(ABC):
     def amplitude(self):
         """Electric field amplitude of the wavefront """
 #         return np.abs(self.wavefront)
-        if accel_math._USE_CUPY:
+        if self.wavefront_gpu is not None:
             return (cp.abs(self.wavefront_gpu)).get()
         else:    
             return np.abs(self.wavefront)
@@ -713,19 +720,21 @@ class BaseWavefront(ABC):
     @property
     def intensity(self):
         """Electric field intensity of the wavefront (i.e. field amplitude squared)"""
-        if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
+#         if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
+        if accel_math._USE_NUMEXPR and self.wavefront_gpu is None:
             w = self.wavefront
             return ne.evaluate("real(abs(w))**2")
-        elif accel_math._USE_CUPY:
-            return (cp.abs(self.wavefront_gpu)).get()
+        elif self.wavefront_gpu is not None:
+            return (cp.abs(self.wavefront_gpu)**2).get()
         else:
             return np.abs(self.wavefront) ** 2
+        
 
     @property
     def phase(self):
         """Phase of the wavefront, in radians"""
 #         return np.angle(self.wavefront)
-        if accel_math._USE_CUPY:
+        if self.wavefront_gpu is not None:
             return (cp.angle(self.wavefront_gpu)).get()
         else:    
             return np.angle(self.wavefront)
@@ -781,12 +790,12 @@ class BaseWavefront(ABC):
         _log.info("Resampling wavefront to detector with {} pixels and {}. Zoom factor is {:.5f}".format(
             detector.shape, detector.pixelscale, pixscale_ratio))
 
-        _log.debug("Wavefront pixel scale:        {:.3f}".format(self.pixelscale.to(detector.pixelscale.unit)))
-        _log.debug("Desired detector pixel scale: {:.3f}".format(detector.pixelscale))
+        _log.debug("Wavefront pixel scale:        {:.3e}".format(self.pixelscale.to(detector.pixelscale.unit)))
+        _log.debug("Desired detector pixel scale: {:.3e}".format(detector.pixelscale))
         _log.debug("Wavefront FOV:        {} pixels, {:.3f}".format(self.shape,
                                                                     self.shape[0]*u.pixel*self.pixelscale.to(
                                                                     detector.pixelscale.unit)))
-        _log.debug("Desired detector FOV: {} pixels, {:.3f}".format(detector.shape,
+        _log.debug("Desired detector FOV: {} pixels, {:.3e}".format(detector.shape,
                                                                     detector.shape[0]*u.pixel*detector.pixelscale))
 
         def make_axis(npix, step):
@@ -800,8 +809,11 @@ class BaseWavefront(ABC):
 
         # Crop wavefront down to detector size + margin- don't waste computation interpolating
         # parts of plane that get cropped out later anyways
-        cropped_wf = utils.pad_or_crop_to_shape(self.wavefront, crop_shape)
-
+#         cropped_wf = utils.pad_or_crop_to_shape(self.wavefront, crop_shape)
+        if self.wavefront_gpu is not None:
+            cropped_wf = utils.pad_or_crop_to_shape(self.wavefront_gpu, crop_shape)
+        else:
+            cropped_wf = utils.pad_or_crop_to_shape(self.wavefront, crop_shape)
         # Input and output axes for interpolation.  The interpolated wavefront will be evaluated
         # directly onto the detector axis, so don't need to crop afterwards.
         x_in = make_axis(crop_shape[0], self.pixelscale.to(u.m/u.pix).value)
@@ -814,6 +826,8 @@ class BaseWavefront(ABC):
             Bind arguments to scipy's RectBivariateSpline function.
             For data on a regular 2D grid, RectBivariateSpline is more efficient than interp2d.
             """
+            if accel_math._USE_CUPY:
+                arr = arr.get()
             return scipy.interpolate.RectBivariateSpline(
                 x_in, y_in, arr, kx=detector.interp_order, ky=detector.interp_order)
 
@@ -826,7 +840,12 @@ class BaseWavefront(ABC):
         new_wf *= 1. / pixscale_ratio
 
         self.ispadded = False   # if a pupil detector, avoid auto-cropping padded pixels on output
-        self.wavefront = new_wf
+#         self.wavefront = new_wf
+        if accel_math._USE_CUPY:
+            print('\t\tNew wavefront assigned to wavefront_gpu.', isinstance(new_wf, cp.ndarray))
+            self.wavefront_gpu = cp.array(new_wf)
+        else:
+            self.wavefront = new_wf
         self.pixelscale = detector.pixelscale
 
     @utils.quantity_input(Xangle=u.arcsec, Yangle=u.arcsec)
@@ -3162,6 +3181,10 @@ class FITSOpticalElement(OpticalElement):
 
                 self.amplitude = scipy.ndimage.shift(self.amplitude, (rolly, rollx))
                 self.opd = scipy.ndimage.shift(self.opd, (rolly, rollx))
+                
+        if accel_math._USE_CUPY:
+            self.amplitude_gpu = cp.array(self.amplitude)
+            self.opd_gpu = cp.array(self.opd)
 
     @property
     def pupil_diam(self):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -797,8 +797,6 @@ class BaseWavefront(ABC):
             Bind arguments to scipy's RectBivariateSpline function.
             For data on a regular 2D grid, RectBivariateSpline is more efficient than interp2d.
             """
-#             if accel_math._USE_CUPY:
-#                 x_in, y_in = ( x_in.get(), y_in.get() )
             return scipy.interpolate.RectBivariateSpline(x_in, y_in, arr, 
                                                          kx=detector.interp_order, ky=detector.interp_order)
 
@@ -903,8 +901,8 @@ class BaseWavefront(ABC):
             rot_imag = np.rot90(self.wavefront.imag, k=-k)
         else:
             # arbitrary free rotation with interpolation
-            rot_real = scipy.ndimage.interpolation.rotate(self.wavefront.real, -angle, reshape=False)  # negative = CCW
-            rot_imag = scipy.ndimage.interpolation.rotate(self.wavefront.imag, -angle, reshape=False)
+            rot_real = ndimage.interpolation.rotate(self.wavefront.real, -angle, reshape=False)  # negative = CCW
+            rot_imag = ndimage.interpolation.rotate(self.wavefront.imag, -angle, reshape=False)
         self.wavefront = rot_real + 1.j * rot_imag
 
         self.history.append('Rotated by {:.2f} degrees, CCW'.format(angle))
@@ -3047,11 +3045,11 @@ class FITSOpticalElement(OpticalElement):
                     # arbitrary free rotation with interpolation
                     # do rotation with interpolation, but try to clean up some of the artifacts afterwards.
                     # this is imperfect at best, of course...
-                    self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
-                                                                        reshape=False).clip(min=0, max=1.0)
+                    self.amplitude = ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
+                                                                  reshape=False).clip(min=0, max=1.0)
                     wnoise = (self.amplitude < 1e-3) & (self.amplitude > 0)
                     self.amplitude[wnoise] = 0
-                    self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
+                    self.opd = ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
                 _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)
                 self._rotation = rotation
 
@@ -3155,8 +3153,8 @@ class FITSOpticalElement(OpticalElement):
                               rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0]))
                     self._shift = (rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0])
 
-                self.amplitude = scipy.ndimage.shift(self.amplitude, (rolly, rollx))
-                self.opd = scipy.ndimage.shift(self.opd, (rolly, rollx))
+                self.amplitude = ndimage.shift(self.amplitude, (rolly, rollx))
+                self.opd = ndimage.shift(self.opd, (rolly, rollx))
 
     @property
     def pupil_diam(self):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2486,7 +2486,7 @@ class OpticalElement(object):
                            " zoom factor of {:.3g}".format(zoom))
                 _log.debug("resampled optic shape: {}   wavefront shape: {}".format(resampled_amplitude.shape,
                                                                                     wave.shape))
-
+                
                 lx, ly = resampled_amplitude.shape
                 # crop down to match size of wavefront:
                 lx_w, ly_w = wave.amplitude.shape
@@ -2755,7 +2755,7 @@ class ArrayOpticalElement(OpticalElement):
     """ Defines an arbitrary optic, based on amplitude transmission and/or OPD given as numpy arrays.
 
     This is a very lightweight wrapper for the base OpticalElement class, which just provides some
-    additional convenience features in the initializer..
+    additional convenience features in the initializer.
     """
 
     def __init__(self, opd=None, transmission=None, pixelscale=None, **kwargs):
@@ -2766,6 +2766,8 @@ class ArrayOpticalElement(OpticalElement):
             self.amplitude = transmission
             if opd is None:
                 self.opd = np.zeros_like(transmission)
+        elif transmission is None and opd is not None:
+            self.amplitude = np.ones_like(opd)
 
         if pixelscale is not None:
             self.pixelscale = pixelscale

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -1,7 +1,6 @@
 # Tests for individual Optic classes
 
 import matplotlib.pyplot as pl
-import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 
@@ -9,6 +8,13 @@ from .. import poppy_core
 from .. import optics
 from .. import zernike
 from .test_core import check_wavefront
+
+from .. import accel_math
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+else: 
+    import numpy as np
 
 wavelength=1e-6
 
@@ -89,7 +95,7 @@ def test_shifting_optics( npix=30,  grid_size = 3, display=False):
     Tests the fix for #247
     """
     import poppy
-    pixsize =grid_size/npix
+    pixsize = grid_size/npix
     shift_size = np.round(0.2/pixsize)*pixsize  # by construction, an integer # of pixels
 
     # Create a reference array

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -12,8 +12,6 @@ from .test_core import check_wavefront
 
 wavelength=1e-6
 
-
-
 #def test_OpticalElement():
 #    pass
 

--- a/poppy/tests/test_wfe.py
+++ b/poppy/tests/test_wfe.py
@@ -325,10 +325,14 @@ def test_KolmogorovWFE():
         ps3 = KolmogorovWFE.power_spectrum(wf, kind='von Karman')
         ps4 = KolmogorovWFE.power_spectrum(wf, kind='Hill')
         
-        assert(np.round(ps1[0,0].value, 9) == np.round(0.0, 9))
-        assert(np.round(ps2[0,0].value, 9) == np.round(0.0, 9))
-        assert(np.round(ps3[0,0].value, 9) == np.round(0.0, 9))
-        assert(np.round(ps4[0,0].value, 9) == np.round(0.0, 9))
+#         assert(np.round(ps1[0,0].value, 9) == np.round(0.0, 9))
+#         assert(np.round(ps2[0,0].value, 9) == np.round(0.0, 9))
+#         assert(np.round(ps3[0,0].value, 9) == np.round(0.0, 9))
+#         assert(np.round(ps4[0,0].value, 9) == np.round(0.0, 9))
+        assert(np.round(ps1[0,0], 9) == np.round(0.0, 9))
+        assert(np.round(ps2[0,0], 9) == np.round(0.0, 9))
+        assert(np.round(ps3[0,0], 9) == np.round(0.0, 9))
+        assert(np.round(ps4[0,0], 9) == np.round(0.0, 9))
     
     def test_KolmogorovWFE_correlation(num_ensemble = 2000, npix = 64):
         # verify correlation of random numbers

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1181,8 +1181,10 @@ def pad_or_crop_to_shape(array, target_shape):
 
     lx, ly = array.shape
     lx_w, ly_w = target_shape
-    border_x = np.abs(lx - lx_w) // 2
-    border_y = np.abs(ly - ly_w) // 2
+#     border_x = np.abs(lx - lx_w) // 2
+#     border_y = np.abs(ly - ly_w) // 2
+    border_x = abs(lx - lx_w) // 2
+    border_y = abs(ly - ly_w) // 2
 
     if (lx < lx_w) or (ly < ly_w):
         _log.debug("Array shape " + str(array.shape) + " is smaller than desired shape " + str(

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -28,6 +28,10 @@ try:
 except ImportError:
     pyfftw = None
 
+from . import accel_math
+if accel_math._USE_CUPY:
+    import cupy as cp
+    
 _log = logging.getLogger('poppy')
 
 _loaded_fftw_wisdom = False
@@ -1089,7 +1093,11 @@ def pad_to_oversample(array, oversample):
     """
     npix = array.shape[0]
     n = int(np.round(npix * oversample))
-    padded = np.zeros(shape=(n, n), dtype=array.dtype)
+#     padded = np.zeros(shape=(n, n), dtype=array.dtype)
+    if isinstance(array, cp.ndarray):
+        padded = cp.zeros(shape=(n, n), dtype=array.dtype)
+    else:
+        padded = np.zeros(shape=(n, n), dtype=array.dtype)
     n0 = float(npix) * (oversample - 1) / 2
     n1 = n0 + npix
     n0 = int(round(n0))  # because astropy test_plugins enforces integer indices

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     pyfftw = None
 
+import sys
 from . import accel_math
 if accel_math._USE_CUPY:
     import cupy as cp
@@ -1094,6 +1095,13 @@ def pad_to_oversample(array, oversample):
     npix = array.shape[0]
     n = int(np.round(npix * oversample))
 #     padded = np.zeros(shape=(n, n), dtype=array.dtype)
+#     if 'cupy' in sys.modules:
+#         if isinstance(array, cp.ndarray):
+#             padded = cp.zeros(shape=(n, n), dtype=array.dtype)
+#         else:
+#             padded = np.zeros(shape=(n, n), dtype=array.dtype)
+#     else:
+#         padded = np.zeros(shape=(n, n), dtype=array.dtype)
     if isinstance(array, cp.ndarray):
         padded = cp.zeros(shape=(n, n), dtype=array.dtype)
     else:
@@ -1155,7 +1163,7 @@ def pad_or_crop_to_shape(array, target_shape):
 
     Parameters
     ----------
-    array : complex ndarray
+    array : complex ndarray (numpy or cupy)
         The phasor, produced by some call to get_phasor of an OpticalElement
     target_shape : 2-tuple
         The shape we should pad or crop that phasor to
@@ -1182,9 +1190,12 @@ def pad_or_crop_to_shape(array, target_shape):
     if (lx < lx_w) or (ly < ly_w):
         _log.debug("Array shape " + str(array.shape) + " is smaller than desired shape " + str(
             [lx_w, ly_w]) + "; will attempt to zero-pad the array")
-
-        resampled_array = np.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
-        resampled_array[border_x:border_x + lx, border_y:border_y + ly] = array
+#         resampled_array = np.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
+        if isinstance(array, cp.ndarray):
+            resampled_array = cp.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
+        else:
+            resampled_array = np.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
+        resampled_array[border_x:border_x + lx, border_y:border_y + ly] = array # FUCK THIS LINE OF CODE
         _log.debug("  Padded with a {:d} x {:d} border to "
                    " match the desired shape".format(border_x, border_y))
 

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -27,10 +27,9 @@ from importlib import reload
 
 from . import accel_math
 
+import numpy
 if accel_math._USE_CUPY:
     import cupy as np
-    import numpy
-    
     rnd = numpy.round
 else:
     import numpy as np

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -830,6 +830,7 @@ class KolmogorovWFE(WavefrontError):
                 k2 = (qx**2 + qy**2)
                 if kind=='Tatarski' or kind=='von Karman':
                     m = (5.92/self.inner_scale.to(u.m))**2
+                    print(k2, m, -k2/m)
                     phi *= np.exp(-k2/m)
                 elif kind=='Hill':
                     m = np.sqrt(k2)*self.inner_scale.to(u.m)

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -809,14 +809,14 @@ class KolmogorovWFE(WavefrontError):
         npix = coordinates[0].shape[0]
         pixelscale = wave.pixelscale.to(u.m/u.pixel) * u.pix
         
-        q = np.fft.fftfreq(npix, d=pixelscale.value)*2.0*np.pi
+        q = np.fft.fftfreq(npix, d=pixelscale.value)*2.0*np.pi # so q has units of 1/m?
         
         qx, qy = np.meshgrid(q, q)
         
         q2 = (qx**2 + qy**2)
         if kind=='von Karman':
             if self.outer_scale is not None:
-                q2 += 1.0/self.outer_scale.to(u.m)**2
+                q2 += 1.0/self.outer_scale.to(u.m).value**2
             else:
                 raise ValueError('If von Karman kind of turbulent phase \
                                  screen is chosen, the outer scale L_0 \
@@ -829,13 +829,12 @@ class KolmogorovWFE(WavefrontError):
             if self.inner_scale is not None:
                 k2 = (qx**2 + qy**2)
                 if kind=='Tatarski' or kind=='von Karman':
-                    m = (5.92/self.inner_scale.to(u.m))**2
-                    print(k2, m, -k2/m)
+                    m = (5.92/self.inner_scale.to(u.m).value)**2
                     phi *= np.exp(-k2/m)
                 elif kind=='Hill':
-                    m = np.sqrt(k2)*self.inner_scale.to(u.m)
+                    m = np.sqrt(k2)*self.inner_scale.to(u.m).value # m is supposed to be dimensionless?
                     phi *= (1.0 + 0.70937*m + 2.8235*m**2
-                            - 0.28086*m**3 + 0.08277*m**4) * np.exp(-1.109*m)
+                            - 0.28086*m**3 + 0.08277*m**4) * np.exp(-1.109*m) 
             else:
                 raise ValueError('If von Karman, Hill, or Tatarski kind \
                                  of turbulent phase screen is chosen, the \

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -420,7 +420,7 @@ def zernike_basis_faster(nterms=15, npix=512, outside=np.nan):
         else:
             for k in range(int((n - m) / 2) + 1):
                 coef = ((-1) ** k * factorial(n - k) /
-                        (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
+                        (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
                 output += coef * rho ** (n - 2 * k)
             return output
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -24,7 +24,6 @@ Gram-Schmidt orthonormalization process as applied to this case is
 
 import inspect
 from math import factorial
-import numpy as np
 import scipy
 
 import sys
@@ -33,6 +32,14 @@ import logging
 import astropy.units as u
 
 from poppy.poppy_core import Wavefront
+
+from . import accel_math
+
+import numpy
+if accel_math._USE_CUPY:
+    import cupy as np
+else:
+    import numpy as np
 
 from functools import lru_cache
 
@@ -243,7 +250,7 @@ def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
         raise ValueError("If you provide either the `theta` or `rho` input array, you must "
                          "provide both of them.")
 
-    if not np.all(rho.shape == theta.shape):
+    if not numpy.all(rho.shape == theta.shape):
         raise ValueError('The rho and theta arrays do not have consistent shape.')
 
     aperture = (rho <= 1)

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -420,7 +420,7 @@ def zernike_basis_faster(nterms=15, npix=512, outside=np.nan):
         else:
             for k in range(int((n - m) / 2) + 1):
                 coef = ((-1) ** k * factorial(n - k) /
-                        (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                        (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
                 output += coef * rho ** (n - 2 * k)
             return output
 


### PR DESCRIPTION
This is a copy of PR #499 to the spacetelescope/poppy repository.

This is a bit more of an extensive PR as it seeks to add CuPy as an accelerated math option for many computations including FFTs, MFTs, and exponentials for propagation with the OpticalSystem or FresnelOpticalSystem classes. To start with, CuPy is a package for GPU accelerated computing. While POPPY has GPU computing options available with PyOpenCL and with pyculib (which has been deprecated by Numba in favor of CuPy), this implementation seeks to perform all calculations on the GPU until the end of propagation. This reduces time for calculations as arrays no longer need to be transferred between GPU memory and standard memory when performing different calculations. 

CuPy has been designed to be very similar to Numpy and has many of the same features requiring the same syntax to use. An example is numpy.fft.fft2, which with CuPy is cupy.fft.fft2. The catch is that CuPy functions can not be used on Numpy arrays since Numpy arrays are stored on standard memory. As such, the implementation strategy was to use the statement “import cupy as np” when POPPY’s Config has been set to use CuPy. This makes performing all calculations on GPU more seamless as wavefront arrays for Wavefront or FresnelWavefront objects along with optical element phasors are automatically calculated as CuPy arrays. 

In addition to using CuPy for basic computations of FFTs and exponentials, CuPy also enables the use of many SciPy functions through its cupyx functions. The cupyx functions can be imported much like many scipy functions with a statement such as “import cupyx.scipy.ndimage as ndimage”. So many functions for computing array rotations or interpolations are also imported through cupyx or scipy based on POPPY’s Config setup. The same method is also used to compute Bessel functions. 

Currently, many optics have been tested for use with CuPy. A table with these optics is provided below with some comments regarding the functionality of some optics. 
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-a6e38066-7fff-75fd-8214-a1567fec4732"><div dir="ltr" style="margin-left:0pt;" align="left">

Optical Element Class | Compatible with CuPy | Comments
-- | -- | --
CircularAperture | Yes |  
MultiCircularAperture | Yes |  
SquareAperture | Yes |  
RectangularAperture | Yes |  
HexagonAperture | Yes |  
MultiHexagonAperture | Yes |  
NgonAperture | Yes |  
SecondaryObscuration | Yes |  
AsymmetricSecondaryObscuration | Yes |  
CompoundAnalyticOptic | Yes |  
ThinLens | Yes |  
GaussianAperture | Yes |  
KnifeEdge | Yes |  
SquareFieldStop | Yes | These image plane elements have only been tested in Fraunhofer systems since it is difficult to use these elements in Fresnel systems anyway. This is because of the issue in converting to angular units in a Fresnel system.
RectagularFieldStop | Yes
AnnularFieldStop | Yes
HexagonFieldStop | Yes
CircularOcculter | Yes
BarOcculter | Yes
BandLimitedCoronagraph | Yes
IdealFQPM | Yes
ScalarTransmission | Yes |  
InverseTransmission | Yes |  
ScalarOpticalPathDifference | Yes |  
ZernikeWFE | Yes |  
KolmogorovWFE | Yes | Does not pass test when using Tatarski power spectrum.
SineWaveWFE | Yes |  
StatisticalPSDWFE | Yes | Had to implement hack found in Issue #452, pre-existing bug not related to CuPyNote: slight differences in numpy vs cupy random generators so does not produce the exact same result with the same seed value.
PowerSpectrumWFE | Yes | Had to assume opd is calculated in nanometers and then rescale it to meters, there should be a better solution to this. Note: slight differences in numpy vs cupy random generators so does not produce exact same result
ContinuousDeformableMirror | Yes | Influence function must be provided. When using .set_surface(), you should still provide a numpy.ndarray instead of a cupy.ndarray.
HexSegmentedDeformableMirror | Yes | These segmented optics are functional but when converted to an ArrayOpticalElement with fixed_sampling_optic(), the OPD is only 0. Still not 100% sure why but it does not seem to be an issue with CuPy because get_opd() functions as expected.
CircularSegmentedDeformableMirror | Yes
ArrayOpticalElement | Yes |  
FITSOpticalElement | Yes |  
FixedSamplingImagePlaneElement | Yes |  

</div></b>

All tests in the test suite for POPPY were also run. Currently, there is only an issue with the KolmogorovWFE test not passing due to a units issue in an exponential. This only comes up when using a Tatarski power spectrum. The tests have only been run with standard CPU computations to make sure POPPY is not running into critical errors because of the addition of CuPy even if a user isn’t using the CuPy feature. 


Computation comparisons have been performed to illustrate the benefit of this accelerated computing feature. Below are comparisons of the times required for a PSF to be calculated for varying array sizes using the MKL FFT option versus the CuPy calculations. The optical systems tested had 5 different surfaces/optics. The system used for these comparisons was the University of Arizona’s HPC Puma nodes. The node utilized 32 AMD EPYC 7642 CPUs and the NVIDIA Tesla V100S GPU. 

Propagation Type | Array Size | MKL Method Times [s] | CuPy Method Times [s] | Speed Up Factor
-- | -- | -- | -- | --
Fraunhofer | 1024 | 0.218 | 0.0261 | 8.35
Fraunhofer | 2048 | 0.755 | 0.0294 | 25.7
Fraunhofer | 4096 | 3.36 | 0.0423 | 79.4
Fresnel | 1024 | 0.714 | 0.0438 | 16.3
Fresnel | 2048 | 4.16 | 0.0845 | 49.2
Fresnel | 4096 | 17.5 | 0.225 | 77.8

</div></b>

One catch with this is none of POPPY’s display functionality is compatible with CuPy. This is because matplotlib cannot plot CuPy arrays since they are only on GPU memory. In order to obtain a Numpy array from a CuPy array, the “cupy.ndarray.get()” method can be used. So users can obtain intensity and phase arrays by adding .get().

It should be noted that the following POPPY features have not been tested for functionality with CuPy:
- PhysicalFresnelWavefront
- Active optics such as the TipTiltStage (found in active_optics.py)
- The Instrument class
- Special propagation features such as SemiAnalyticCoronagraph (found in special_prop.py)
- Sub-sampled optics such as ShackHartmannWavefrontSensor
- Floating-window centroid calculations