### PR TITLE
Changed CuPy Implementation

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,7 +16,7 @@ jobs:
 
           - name: Coverage test in Python 3
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-syn-cov
 
           - name: Check for Sphinx doc build errors
@@ -36,7 +36,7 @@ jobs:
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-latest-test
 
           - name: Try minimum supported versions

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,33 +16,33 @@ jobs:
 
           - name: Coverage test in Python 3
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-syn-cov
+            python: 3.10
+            toxenv: py310-syn-cov
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             toxenv: docbuild
 
           - name: Check accelerated math version
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-numexpr-mkl-cov
+            python: 3.9
+            toxenv: py39-numexpr-mkl-cov
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-astropydev-test
+            python: 3.9
+            toxenv: py39-astropydev-test
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-latest-test
+            python: 3.10
+            toxenv: py310-latest-test
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-legacy-test
+            python: 3.8
+            toxenv: py38-legacy-test
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,22 +5,12 @@ on:
     types: [released]
 
 jobs:
-  build:
-      name: Publish release to PyPI
-      env:
-        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
-        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
-        PYPI_TEST: ${{ secrets.PYPI_TEST }}
-        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
-      runs-on: ubuntu-latest
-      steps:
-
-          # Check out the commit containing this workflow file.
-          - name: checkout repo
-            uses: actions/checkout@v2
-
-          - name: custom action
-            uses: spacetelescope/action-publish_to_pypi@master
-            id: custom_action_0
+  publish:
+    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ POPPY may be installed one of three different ways.
 Requirements
 --------------
 
-* Python 3.7, or more recent.
+* Python 3.8, or more recent.
 * The standard Python scientific stack: :py:mod:`numpy`, :py:mod:`scipy`,
   :py:mod:`matplotlib`
 * POPPY relies upon the `astropy

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -114,17 +114,6 @@ from . import wfe
 from . import dms
 from . import active_optics
 
-# from importlib import reload
-# reload(poppy_core)
-# reload(utils)
-# reload(optics)
-# reload(misc)
-# reload(fresnel)
-# reload(physical_wavefront)
-# reload(wfe)
-# reload(dms)
-# reload(active_optics)
-
 from .poppy_core import *
 from .utils import *
 from .optics import *

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -25,7 +25,6 @@ except ImportError:
 
 __minimum_python_version__ = "3.7"
 
-
 class UnsupportedPythonError(Exception):
     pass
 
@@ -68,7 +67,7 @@ class Conf(_config.ConfigNamespace):
             'is available)?')
     use_opencl = _config.ConfigItem(True, 'Use OpenCL for FFTs on GPU (assuming it' +
             'is available)?')
-    use_cupy = _config.ConfigItem(True, 'Use cupy for FFTs on GPU (assuming it' +
+    use_cupy = _config.ConfigItem(True, 'Use CuPy for FFTs on GPU (assuming it' +
             'is available)?')
     
     use_numexpr = _config.ConfigItem(True, 'Use NumExpr to accelerate array math (assuming it' +
@@ -114,6 +113,17 @@ from . import physical_wavefront
 from . import wfe
 from . import dms
 from . import active_optics
+
+# from importlib import reload
+# reload(poppy_core)
+# reload(utils)
+# reload(optics)
+# reload(misc)
+# reload(fresnel)
+# reload(physical_wavefront)
+# reload(wfe)
+# reload(dms)
+# reload(active_optics)
 
 from .poppy_core import *
 from .utils import *

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     __version__ = ''
 
-__minimum_python_version__ = "3.7"
+__minimum_python_version__ = "3.8"
 
 
 class UnsupportedPythonError(Exception):

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -61,6 +61,7 @@ except ImportError:
 
 try: ###############################################################
     import cupy as cp
+    cp.cuda.Device() # checks if a GPU exists
     _CUPY_PLANS = {} 
     _CUPY_AVAILABLE = True
 except:

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -97,11 +97,9 @@ def update_math_settings():
     if _USE_CUPY:
         _ncp = cp
         _scipy = cupyx.scipy
-#         print('Accelerated math settings updated: using CuPy')
     else:
         _ncp = np
         _scipy = scipy
-#         print('Accelerated math settings updated: using standard Numpy')
 
 def _float():
     """ Returns numpy data type for desired precision based on configuration """

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -63,6 +63,8 @@ except ImportError:
 try: ###############################################################
     import cupy as cp
     import cupyx.scipy.ndimage
+    import cupyx.scipy.signal
+    import cupyx.scipy.special
     cp.cuda.Device() # checks if a GPU exists
     _CUPY_PLANS = {} 
     _CUPY_AVAILABLE = True
@@ -95,9 +97,11 @@ def update_math_settings():
     if _USE_CUPY:
         _ncp = cp
         _scipy = cupyx.scipy
+#         print('Accelerated math settings updated: using CuPy')
     else:
         _ncp = np
         _scipy = scipy
+#         print('Accelerated math settings updated: using standard Numpy')
 
 def _float():
     """ Returns numpy data type for desired precision based on configuration """

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -15,15 +15,6 @@ accel_math.update_math_settings()
 global _ncp, _scipy
 from .accel_math import _ncp, _scipy
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-#     import cupyx.scipy.ndimage as ndimage
-#     import cupyx.scipy.signal as signal
-# else:
-#     import numpy as np
-#     import scipy.ndimage as ndimage
-#     import scipy.signal as signal
 import logging
 
 _log = logging.getLogger('poppy')

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -12,16 +12,10 @@ from . import accel_math
 accel_math.update_math_settings()
 global _ncp
 from .accel_math import _ncp
-
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-# else:
-#     import numpy as np
     
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
-    pi = numpy.pi  # needed for evaluation inside numexpr strings.
+    pi = np.pi  # needed for evaluation inside numexpr strings.
 
 _log = logging.getLogger('poppy')
 
@@ -365,10 +359,6 @@ class FresnelWavefront(BaseWavefront):
         self._y -= (self.wavefront.shape[0]) / 2.0
         self._x -= (self.wavefront.shape[1]) / 2.0
         
-#         print('\nFrom __init__() in FresnelWavefront(): ')
-#         print('\t', type(self._x))
-#         print('\t', _ncp)
-        
         """saves x and y indices for future use"""
 
         # FIXME MP: this self.n attribute appears unnecessary?
@@ -533,10 +523,8 @@ class FresnelWavefront(BaseWavefront):
             pixel_scale_x, pixel_scale_y = pixelscale_mpix, pixelscale_mpix
         
         if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
-#             print('Using NE')
             return ne.evaluate("pixel_scale_y * y"), ne.evaluate("pixel_scale_x * x")
         else:
-#             print('Not using NE')
             return pixel_scale_y * y, pixel_scale_x * x
 
     def coordinates(self):
@@ -562,10 +550,7 @@ class FresnelWavefront(BaseWavefront):
         """
         
         y, x = type(self).pupil_coordinates(self._x, self._y, self._pixelscale_m)
-#         print('\nFrom coordinates() in FresnelWavefront(): ')
-#         print('\t', type(x))
-#         print('\t', _ncp)
-        
+
         # If the wavefront been explicitly set to use angular units,
         # for instance at an image plane,then
         # then convert to angular coordinates using the focal length

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -11,6 +11,10 @@ from poppy.poppy_core import PlaneType, Wavefront, BaseWavefront, BaseOpticalSys
 from . import utils
 from . import accel_math
 
+accel_math.update_math_settings()
+global _ncp
+from .accel_math import _ncp
+
 import numpy
 if accel_math._USE_CUPY:
     import cupy as np
@@ -84,7 +88,6 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
             opd = (x ** 2 + y ** 2)  / (2.0 *z)
 
         return opd
-
 
 
 class _QuadPhaseShifted(QuadPhase):

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -12,12 +12,6 @@ accel_math.update_math_settings()
 global _ncp
 from .accel_math import _ncp
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-# else:
-#     import numpy as np
-
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
 
@@ -209,10 +203,7 @@ def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None,
 
     if xarray is None or yarray is None:
         yarray, xarray = _ncp.indices(shape)
-    
-#     print('\nIn filled_circle_aa(): ') 
-#     print('\t',type(xarray))
-#     print('\t',_ncp)
+        
     r = _ncp.sqrt( (xarray-xcenter)**2 + (yarray-ycenter)**2)
     array[r < radius ]  = fillvalue
 

--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -139,7 +139,7 @@ def matrix_dft(plane, nlamD, npix,
     
     if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
         return matrix_dft_numexpr(plane, nlamD, npix,
-               offset=offset, inverse=inverse, centering=centering)
+                                  offset=offset, inverse=inverse, centering=centering)
     float = accel_math._float()
 
     npupY, npupX = plane.shape
@@ -148,7 +148,7 @@ def matrix_dft(plane, nlamD, npix,
         if np.isscalar(npix):
             npixY, npixX = float(npix), float(npix)
         else:
-            npixY, npixX = tuple(np.asarray(npix, dtype=float))
+            npixY, npixX = tuple(_ncp.asarray(npix, dtype=float))
     except ValueError:
         raise ValueError(
             "'npix' must be supplied as a scalar (for square arrays) or as "
@@ -163,7 +163,7 @@ def matrix_dft(plane, nlamD, npix,
         if np.isscalar(nlamD):
             nlamDY, nlamDX = float(nlamD), float(nlamD)
         else:
-            nlamDY, nlamDX = tuple(np.asarray(nlamD, dtype=float))
+            nlamDY, nlamDX = tuple(_ncp.asarray(nlamD, dtype=float))
     except ValueError:
         raise ValueError(
             "'nlamD' must be supplied as a scalar (for square arrays) or as"
@@ -189,51 +189,51 @@ def matrix_dft(plane, nlamD, npix,
 
 
     if centering == FFTSTYLE:
-        Xs = (np.arange(npupX, dtype=float) - (npupX / 2)) * dX
-        Ys = (np.arange(npupY, dtype=float) - (npupY / 2)) * dY
+        Xs = (_ncp.arange(npupX, dtype=float) - (npupX / 2)) * dX
+        Ys = (_ncp.arange(npupY, dtype=float) - (npupY / 2)) * dY
 
-        Us = (np.arange(npixX, dtype=float) - npixX / 2) * dU
-        Vs = (np.arange(npixY, dtype=float) - npixY / 2) * dV
+        Us = (_ncp.arange(npixX, dtype=float) - npixX / 2) * dU
+        Vs = (_ncp.arange(npixY, dtype=float) - npixY / 2) * dV
     elif centering == ADJUSTABLE:
         if offset is None:
             offsetY, offsetX = 0.0, 0.0
         else:
             try:
-                offsetY, offsetX = tuple(np.asarray(offset, dtype=float))
+                offsetY, offsetX = tuple(_ncp.asarray(offset, dtype=float))
             except ValueError:
                 raise ValueError(
                     "'offset' must be supplied as a 2-tuple with "
                     "(y_offset, x_offset) as floating point values"
                 )
-        Xs = (np.arange(npupX, dtype=float) - float(npupX) / 2.0 - offsetX + 0.5) * dX
-        Ys = (np.arange(npupY, dtype=float) - float(npupY) / 2.0 - offsetY + 0.5) * dY
+        Xs = (_ncp.arange(npupX, dtype=float) - float(npupX) / 2.0 - offsetX + 0.5) * dX
+        Ys = (_ncp.arange(npupY, dtype=float) - float(npupY) / 2.0 - offsetY + 0.5) * dY
 
-        Us = (np.arange(npixX, dtype=float) - float(npixX) / 2.0 - offsetX + 0.5) * dU
-        Vs = (np.arange(npixY, dtype=float) - float(npixY) / 2.0 - offsetY + 0.5) * dV
+        Us = (_ncp.arange(npixX, dtype=float) - float(npixX) / 2.0 - offsetX + 0.5) * dU
+        Vs = (_ncp.arange(npixY, dtype=float) - float(npixY) / 2.0 - offsetY + 0.5) * dV
     elif centering == SYMMETRIC:
-        Xs = (np.arange(npupX, dtype=float) - float(npupX) / 2.0 + 0.5) * dX
-        Ys = (np.arange(npupY, dtype=float) - float(npupY) / 2.0 + 0.5) * dY
+        Xs = (_ncp.arange(npupX, dtype=float) - float(npupX) / 2.0 + 0.5) * dX
+        Ys = (_ncp.arange(npupY, dtype=float) - float(npupY) / 2.0 + 0.5) * dY
 
-        Us = (np.arange(npixX, dtype=float) - float(npixX) / 2.0 + 0.5) * dU
-        Vs = (np.arange(npixY, dtype=float) - float(npixY) / 2.0 + 0.5) * dV
+        Us = (_ncp.arange(npixX, dtype=float) - float(npixX) / 2.0 + 0.5) * dU
+        Vs = (_ncp.arange(npixY, dtype=float) - float(npixY) / 2.0 + 0.5) * dV
     else:
         raise ValueError("Invalid centering style")
 
-    XU = np.outer(Xs, Us)
-    YV = np.outer(Ys, Vs)
+    XU = _ncp.outer(Xs, Us)
+    YV = _ncp.outer(Ys, Vs)
 
     # SIGN CONVENTION: plus signs in exponent for basic forward propagation, with
     # phase increasing with time. This convention differs from prior poppy version < 1.0
     if inverse:
-        expYV = np.exp(-2.0 * np.pi * 1j * YV).T
-        expXU = np.exp(-2.0 * np.pi * 1j * XU)
-        t1 = np.dot(expYV, plane)
-        t2 = np.dot(t1, expXU)
+        expYV = _ncp.exp(-2.0 * np.pi * 1j * YV).T
+        expXU = _ncp.exp(-2.0 * np.pi * 1j * XU)
+        t1 = _ncp.dot(expYV, plane)
+        t2 = _ncp.dot(t1, expXU)
     else:
-        expXU = np.exp(-2.0 * np.pi * -1j * XU)
-        expYV = np.exp(-2.0 * np.pi * -1j * YV).T
-        t1 = np.dot(expYV, plane)
-        t2 = np.dot(t1, expXU)
+        expXU = _ncp.exp(-2.0 * np.pi * -1j * XU)
+        expYV = _ncp.exp(-2.0 * np.pi * -1j * YV).T
+        t1 = _ncp.dot(expYV, plane)
+        t2 = _ncp.dot(t1, expXU)
 
     norm_coeff = np.sqrt((nlamDY * nlamDX) / (npupY * npupX * npixY * npixX))
     return norm_coeff * t2

--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -54,18 +54,23 @@
 
 __all__ = ['MatrixFourierTransform']
 
+import numpy as np
 from . import conf
 from . import accel_math
+
+accel_math.update_math_settings()
+global _ncp
+from .accel_math import _ncp
+
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
     
-import numpy
-if accel_math._USE_CUPY:
-    import cupy as np
-    rnd = numpy.round
-else:
-    import numpy as np
-    rnd = np.round
+# if accel_math._USE_CUPY:
+#     import cupy as np
+#     rnd = numpy.round
+# else:
+#     import numpy as np
+#     rnd = np.round
 
 import logging
 _log = logging.getLogger('poppy')
@@ -127,7 +132,11 @@ def matrix_dft(plane, nlamD, npix,
         will be displaced from the central pixel (or cross). Given as
         (offsetY, offsetX).
     """
-
+    
+    accel_math.update_math_settings()
+    global _ncp
+    from .accel_math import _ncp
+    
     if accel_math._USE_NUMEXPR and not accel_math._USE_CUPY:
         return matrix_dft_numexpr(plane, nlamD, npix,
                offset=offset, inverse=inverse, centering=centering)
@@ -440,6 +449,11 @@ class MatrixFourierTransform:
     """
 
     def __init__(self, centering="ADJUSTABLE", verbose=False):
+        
+        accel_math.update_math_settings()
+        global _ncp
+        from .accel_math import _ncp
+        
         self.verbose = verbose
         centering = centering.upper()
         if centering == FFTRECT:  # for backwards compatibility

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -336,9 +336,6 @@ class AnalyticOpticalElement(OpticalElement):
             else:
                 y -= float(self.shift_y)
         if hasattr(self, "rotation"):
-#             angle = np.deg2rad(self.rotation)
-#             xp = np.cos(angle) * x + np.sin(angle) * y
-#             yp = -np.sin(angle) * x + np.cos(angle) * y
             angle = numpy.deg2rad(self.rotation)
             xp = numpy.cos(angle).value * x + numpy.sin(angle).value * y
             yp = -numpy.sin(angle).value * x + numpy.cos(angle).value * y

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -10,12 +10,15 @@ from abc import ABC, abstractmethod
 
 from . import utils
 from . import conf
-from . import accel_math
 from .poppy_core import OpticalElement, Wavefront, BaseWavefront, PlaneType, _RADIANStoARCSEC
-from .accel_math import _exp, _r, _float, _complex
 from . import geometry
 
-from importlib import reload
+from . import accel_math
+from .accel_math import _exp, _r, _float, _complex
+
+accel_math.update_math_settings()
+global _ncp
+from .accel_math import _ncp
 
 import numpy
 if accel_math._USE_CUPY:

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -519,7 +519,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
             sigmar.clip(np.finfo(sigmar.dtype).tiny, out=sigmar)  # avoid divide by zero -> NaNs
 
 #             self.transmission = (1 - (2 * scipy.special.jn(1, sigmar) / sigmar) ** 2)
-            self.transmission = (1 - (2 * j1(sigmar) / sigmar) ** 2)
+            self.transmission = (1 - (2 * _scipy.special.j1(sigmar) / sigmar) ** 2)
             self.transmission[r == 0] = 0  # special case center point (value based on L'Hopital's rule)
         elif self.kind == 'nircamcircular':
             # larger sigma implies narrower peak? TBD verify if this is correct

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -20,14 +20,6 @@ accel_math.update_math_settings()
 global _ncp
 from .accel_math import _ncp
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-#     from cupyx.scipy.special import j1
-# else:
-#     import numpy as np
-#     from scipy.special import j1
-
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
 
@@ -329,9 +321,6 @@ class AnalyticOpticalElement(OpticalElement):
         """
 
         y, x = wave.coordinates()
-#         print('\nFrom get_coordiantes() in OpticalElement(): ')
-#         print('\t', type(x))
-#         print('\t', _ncp)
         
         if hasattr(self, "shift_x"):
             if isinstance(self.shift_x, u.Quantity):
@@ -1200,9 +1189,6 @@ class CircularAperture(AnalyticOpticalElement):
         
         if self._use_gray_pixel:
             pixscale = wave.pixelscale.to(u.meter/u.pixel).value
-#             print('\nIn get_transmission() from CircularAperture(): ') 
-#             print('\t',type(x/pixscale))
-#             print('\t',_ncp)
             self.transmission = geometry.filled_circle_aa(wave.shape, 0, 0, radius/pixscale, x/pixscale, y/pixscale)
         else:
             r = _r(x, y)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -908,8 +908,8 @@ class BaseWavefront(ABC):
             rot_imag = np.rot90(self.wavefront.imag, k=-k)
         else:
             # arbitrary free rotation with interpolation
-            rot_real = ndimage.interpolation.rotate(self.wavefront.real, -angle, reshape=False)  # negative = CCW
-            rot_imag = ndimage.interpolation.rotate(self.wavefront.imag, -angle, reshape=False)
+            rot_real = _scipy.ndimage.interpolation.rotate(self.wavefront.real, -angle, reshape=False)  # negative = CCW
+            rot_imag = _scipy.ndimage.interpolation.rotate(self.wavefront.imag, -angle, reshape=False)
         self.wavefront = rot_real + 1.j * rot_imag
 
         self.history.append('Rotated by {:.2f} degrees, CCW'.format(angle))
@@ -988,8 +988,8 @@ class Wavefront(BaseWavefront):
                  oversample=2, pixelscale=None):
         
         accel_math.update_math_settings()                   # ensure optimal propagation based on user settings
-        global _ncp
-        from .accel_math import _ncp
+        global _ncp, _scipy
+        from .accel_math import _ncp, _scipy
         
         super(Wavefront, self).__init__(wavelength=wavelength,
                                         npix=npix,
@@ -2498,9 +2498,9 @@ class OpticalElement(object):
                 # raise NotImplementedError("Need to implement resampling.")
                 zoom = (self.pixelscale / wave.pixelscale).decompose().value
                 original_opd = self.get_opd(wave)
-                resampled_opd = ndimage.zoom(original_opd, zoom, output=original_opd.dtype, order=self.interp_order)
+                resampled_opd = _scipy.ndimage.zoom(original_opd, zoom, output=original_opd.dtype, order=self.interp_order)
                 original_amplitude = self.get_transmission(wave)
-                resampled_amplitude = ndimage.zoom(original_amplitude, zoom, output=original_amplitude.dtype, order=self.interp_order)
+                resampled_amplitude = _scipy.ndimage.zoom(original_amplitude, zoom, output=original_amplitude.dtype, order=self.interp_order)
                 _log.debug("resampled optic to match wavefront via spline interpolation by a" +
                            " zoom factor of {:.3g}".format(zoom))
                 _log.debug("resampled optic shape: {}   wavefront shape: {}".format(resampled_amplitude.shape,
@@ -3066,11 +3066,11 @@ class FITSOpticalElement(OpticalElement):
                     # arbitrary free rotation with interpolation
                     # do rotation with interpolation, but try to clean up some of the artifacts afterwards.
                     # this is imperfect at best, of course...
-                    self.amplitude = ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
+                    self.amplitude = _scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
                                                                   reshape=False).clip(min=0, max=1.0)
                     wnoise = (self.amplitude < 1e-3) & (self.amplitude > 0)
                     self.amplitude[wnoise] = 0
-                    self.opd = ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
+                    self.opd = _scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
                 _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)
                 self._rotation = rotation
 
@@ -3174,8 +3174,8 @@ class FITSOpticalElement(OpticalElement):
                               rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0]))
                     self._shift = (rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0])
 
-                self.amplitude = ndimage.shift(self.amplitude, (rolly, rollx))
-                self.opd = ndimage.shift(self.opd, (rolly, rollx))
+                self.amplitude = _scipy.ndimage.shift(self.amplitude, (rolly, rollx))
+                self.opd = _scipy.ndimage.shift(self.opd, (rolly, rollx))
 
     @property
     def pupil_diam(self):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2485,7 +2485,7 @@ class OpticalElement(object):
             if hasattr(self, '_resampled_scale') and abs(
                     self._resampled_scale - wave.pixelscale) / self._resampled_scale >= float_tolerance:
                 # we already did this same resampling, so just re-use it!
-                self.phasor = self._resampled_amplitude * np.exp(1.j * self._resampled_opd * scale)
+                self.phasor = self._resampled_amplitude * _ncp.exp(1.j * self._resampled_opd * scale)
             else:
                 # raise NotImplementedError("Need to implement resampling.")
                 zoom = (self.pixelscale / wave.pixelscale).decompose().value
@@ -2776,9 +2776,9 @@ class ArrayOpticalElement(OpticalElement):
         if transmission is not None:
             self.amplitude = transmission
             if opd is None:
-                self.opd = np.zeros_like(transmission)
+                self.opd = _ncp.zeros_like(transmission)
         elif transmission is None and opd is not None:
-            self.amplitude = np.ones_like(opd)
+            self.amplitude = _ncp.ones_like(opd)
 
         if pixelscale is not None:
             self.pixelscale = pixelscale
@@ -2990,7 +2990,7 @@ class FITSOpticalElement(OpticalElement):
 
             if transmission is None:
                 _log.info("No info supplied on amplitude transmission; assuming uniform throughput = 1")
-                self.amplitude = np.ones(self.opd.shape)
+                self.amplitude = _ncp.ones(self.opd.shape)
 
             if opdunits is None:
                 try:

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -26,14 +26,6 @@ from .accel_math import _ncp, _scipy
 
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
-
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-#     import cupyx.scipy.ndimage as ndimage
-# else:
-#     import numpy as np
-#     import scipy.ndimage as ndimage
     
 import logging
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -15,8 +15,13 @@ import astropy.units as u
 from .matrixDFT import MatrixFourierTransform
 from . import utils
 from . import conf
+
 from . import accel_math
 from .accel_math import _float, _complex
+
+accel_math.update_math_settings()
+global _ncp
+from .accel_math import _ncp
 
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
@@ -29,7 +34,6 @@ else:
     import numpy as np
     import scipy.ndimage as ndimage
     
-
 import logging
 
 _log = logging.getLogger('poppy')
@@ -114,7 +118,11 @@ class BaseWavefront(ABC):
     @utils.quantity_input(wavelength=u.meter, diam=u.meter)
     def __init__(self, wavelength=1e-6 * u.meter, npix=1024, dtype=None, diam=1.0 * u.meter,
                  oversample=2):
-
+        
+        accel_math.update_math_settings()                   # ensure optimal propagation based on user settings
+        global _ncp
+        from .accel_math import _ncp
+        
         self.oversample = oversample
 
         self.wavelength = wavelength  # Wavelength in meters (or other unit if specified)
@@ -134,7 +142,7 @@ class BaseWavefront(ABC):
 
         if dtype is None:
             dtype = _complex()
-        self.wavefront = np.ones((npix, npix), dtype=dtype)  # the actual complex wavefront array
+        self.wavefront = _ncp.ones((npix, npix), dtype=dtype)  # the actual complex wavefront array
         self.ispadded = False  # is the wavefront padded for oversampling?
         self.history = []  # List of strings giving a descriptive history of actions
                            # performed on the wavefront. Saved to FITS headers.
@@ -145,7 +153,7 @@ class BaseWavefront(ABC):
 
         self.current_plane_index = 0  # For tracking stages in a calculation
 
-        accel_math.update_math_settings()                   # ensure optimal propagation based on user settings
+#         accel_math.update_math_settings()                   # ensure optimal propagation based on user settings
 
     def __str__(self):
         # TODO add switches for image/pupil planes
@@ -1403,6 +1411,11 @@ class BaseOpticalSystem(ABC):
     """
     def __init__(self, name="unnamed system", verbose=True, oversample=2,
                  npix=None, pupil_diameter=None):
+        
+        accel_math.update_math_settings()
+        global _ncp
+        from .accel_math import _ncp
+        
         self.name = name
         self.verbose = verbose
         self.planes = []  # List of OpticalElements
@@ -2391,7 +2404,11 @@ class OpticalElement(object):
 
     def __init__(self, name="unnamed optic", verbose=True, planetype=PlaneType.unspecified,
                  oversample=1, interp_order=3):
-
+        
+        accel_math.update_math_settings()
+        global _ncp
+        from .accel_math import _ncp
+        
         self.name = name
         """ string. Descriptive Name of this optic"""
         self.verbose = verbose

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2415,8 +2415,8 @@ class OpticalElement(object):
         self._suppress_display = False  # should we avoid displaying this optic on screen?
                                         # (useful for 'virtual' optics like FQPM aligner)
 
-        self.amplitude = np.asarray([1.])
-        self.opd = np.asarray([0.])
+        self.amplitude = _ncp.asarray([1.])
+        self.opd = _ncp.asarray([0.])
         self.pixelscale = None
         self.interp_order = interp_order
 
@@ -2508,8 +2508,8 @@ class OpticalElement(object):
                     _log.warning("After resampling, optic phasor shape " + str(np.shape(resampled_opd)) +
                                  " is smaller than input wavefront " + str(
                                  (lx_w, ly_w)) + "; will zero-pad the rescaled array.")
-                    self._resampled_opd = np.zeros([lx_w, ly_w])
-                    self._resampled_amplitude = np.zeros([lx_w, ly_w])
+                    self._resampled_opd = _ncp.zeros([lx_w, ly_w])
+                    self._resampled_amplitude = _ncp.zeros([lx_w, ly_w])
 
                     self._resampled_opd[border_x:border_x + resampled_opd.shape[0],
                                         border_y:border_y + resampled_opd.shape[1]] = resampled_opd
@@ -2524,7 +2524,7 @@ class OpticalElement(object):
                     _log.debug("trimmed a border of {:d} x {:d} pixels from "
                                "optic to match the wavefront".format(border_x, border_y))
 
-                self.phasor = self._resampled_amplitude * np.exp(1.j * self._resampled_opd * scale)
+                self.phasor = self._resampled_amplitude * _ncp.exp(1.j * self._resampled_opd * scale)
 
         else:
             # compute the phasor directly, without any need to rescale.
@@ -2533,7 +2533,7 @@ class OpticalElement(object):
                 opd = self.get_opd(wave)
                 self.phasor = ne.evaluate("trans * exp(1.j * opd * scale)")
             else:
-                self.phasor = self.get_transmission(wave) * np.exp(1.j * self.get_opd(wave) * scale)
+                self.phasor = self.get_transmission(wave) * _ncp.exp(1.j * self.get_opd(wave) * scale)
 
         # check whether we need to pad or crop the array before returning or not.
         # note: do not pad the phasor if it's just a scalar!
@@ -2898,8 +2898,8 @@ class FITSOpticalElement(OpticalElement):
         if opd is None and transmission is None:  # no input files, so just make a scalar
             _log.warning("No input files specified. You should set transmission=filename or opd=filename.")
             _log.warning("Creating a null optical element. Are you sure that's what you want to do?")
-            self.amplitude = np.asarray([1.])
-            self.opd = np.asarray([0.])
+            self.amplitude = _ncp.asarray([1.])
+            self.opd = _ncp.asarray([0.])
             self.pixelscale = None
             self.name = "-empty-"
         else:
@@ -2910,7 +2910,7 @@ class FITSOpticalElement(OpticalElement):
                     self.amplitude, self.amplitude_header = fits.getdata(self.amplitude_file, header=True)
                     self.amplitude = self.amplitude.astype('=f8')  # ensure native byte order, see #213
                     
-                    self.amplitude = np.array(self.amplitude) # sets to CuPy array if np is cupy
+                    self.amplitude = _ncp.array(self.amplitude) # sets to CuPy array if np is cupy
                     
                     if self.name == 'unnamed optic':
                         self.name = 'Optic from ' + self.amplitude_file
@@ -2942,7 +2942,7 @@ class FITSOpticalElement(OpticalElement):
             # ---- Load OPD file. ---
             if opd is None:
                 # if only amplitude set, create an array of 0s with same size.
-                self.opd = np.zeros(self.amplitude.shape)
+                self.opd = _ncp.zeros(self.amplitude.shape)
                 opdunits = 'meter'  # doesn't matter, it's all zeros, but this will indicate no need to rescale below.
 
             elif isinstance(opd, fits.HDUList):
@@ -2959,7 +2959,7 @@ class FITSOpticalElement(OpticalElement):
                 self.opd, self.opd_header = fits.getdata(self.opd_file, header=True)
                 self.opd = self.opd.astype('=f8')
                 
-                self.opd = np.array(self.opd) # sets to CuPy array if np is cupy
+                self.opd = _ncp.array(self.opd) # sets to CuPy array if np is cupy
                 
                 if self.name == 'unnamed optic': self.name = 'OPD from ' + self.opd_file
                 _log.info(self.name + ": Loaded OPD from " + self.opd_file)
@@ -3052,8 +3052,8 @@ class FITSOpticalElement(OpticalElement):
                 k,remainder = np.divmod(rotation, 90)
                 if remainder==0:
                     # rotation is a multiple of 90
-                    self.amplitude = np.rot90(self.amplitude, k=-k)   # negative = CCW
-                    self.opd = np.rot90(self.opd, k=-k)
+                    self.amplitude = _ncp.rot90(self.amplitude, k=-k)   # negative = CCW
+                    self.opd = _ncp.rot90(self.opd, k=-k)
                 else:
                     # arbitrary free rotation with interpolation
                     # do rotation with interpolation, but try to clean up some of the artifacts afterwards.

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -285,7 +285,7 @@ def display_psf(hdulist_or_filename, ext=0, vmin=1e-7, vmax=1e-1,
                 orientation=colorbar_orientation
             )
         if scale.lower() == 'log':
-            ticks = np.logspace(np.log10(vmin), np.log10(vmax), int(rnd(np.log10(vmax / vmin) + 1)))
+            ticks = np.logspace(np.log10(vmin), np.log10(vmax), int(np.round(np.log10(vmax / vmin) + 1)))
             if colorbar_orientation == 'horizontal' and vmax == 1e-1 and vmin == 1e-8:
                 ticks = [1e-8, 1e-6, 1e-4, 1e-2, 1e-1]  # looks better
             cb.set_ticks(ticks)

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -27,17 +27,17 @@ from importlib import reload
 
 from . import accel_math
 
-import numpy
-if accel_math._USE_CUPY:
-    import cupy as np
-    rnd = numpy.round
-else:
-    import numpy as np
-    rnd = np.round
-
 accel_math.update_math_settings()
-global _ncp
-from .accel_math import _ncp
+global _ncp, _scipy
+from .accel_math import _ncp, _scipy
+
+# import numpy
+# if accel_math._USE_CUPY:
+#     import cupy as np
+#     rnd = numpy.round
+# else:
+#     import numpy as np
+#     rnd = np.round
 
 try:
     import pyfftw
@@ -1106,7 +1106,7 @@ def pad_to_oversample(array, oversample):
     global _ncp
     from .accel_math import _ncp
     npix = array.shape[0]
-    n = int(rnd(npix * oversample))
+    n = int(np.round(npix * oversample))
     padded = _ncp.zeros(shape=(n, n), dtype=array.dtype)
     n0 = float(npix) * (oversample - 1) / 2
     n1 = n0 + npix
@@ -1147,7 +1147,7 @@ def pad_to_size(array, padded_shape):
         outsize0 = padded_shape[0]
         outsize1 = padded_shape[1]
     # npix = array.shape[0]
-    padded = np.zeros(shape=padded_shape, dtype=array.dtype)
+    padded = _ncp.zeros(shape=padded_shape, dtype=array.dtype)
     n0 = (outsize0 - array.shape[0]) // 2  # pixel offset for the inner array
     m0 = (outsize1 - array.shape[1]) // 2  # pixel offset in second dimension
     n1 = n0 + array.shape[0]
@@ -1190,10 +1190,8 @@ def pad_or_crop_to_shape(array, target_shape):
 
     lx, ly = array.shape
     lx_w, ly_w = target_shape
-#     border_x = np.abs(lx - lx_w) // 2
-#     border_y = np.abs(ly - ly_w) // 2
-    border_x = abs(lx - lx_w) // 2
-    border_y = abs(ly - ly_w) // 2
+    border_x = _ncp.abs(lx - lx_w) // 2
+    border_y = _ncp.abs(ly - ly_w) // 2
 
     if (lx < lx_w) or (ly < ly_w):
         _log.debug("Array shape " + str(array.shape) + " is smaller than desired shape " + str(

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -31,14 +31,6 @@ accel_math.update_math_settings()
 global _ncp, _scipy
 from .accel_math import _ncp, _scipy
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-#     rnd = numpy.round
-# else:
-#     import numpy as np
-#     rnd = np.round
-
 try:
     import pyfftw
 except ImportError:

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -35,6 +35,10 @@ else:
     import numpy as np
     rnd = np.round
 
+accel_math.update_math_settings()
+global _ncp
+from .accel_math import _ncp
+
 try:
     import pyfftw
 except ImportError:
@@ -1099,9 +1103,11 @@ def pad_to_oversample(array, oversample):
     ---------
     padToSize
     """
+    global _ncp
+    from .accel_math import _ncp
     npix = array.shape[0]
     n = int(rnd(npix * oversample))
-    padded = np.zeros(shape=(n, n), dtype=array.dtype)
+    padded = _ncp.zeros(shape=(n, n), dtype=array.dtype)
     n0 = float(npix) * (oversample - 1) / 2
     n1 = n0 + npix
     n0 = int(round(n0))  # because astropy test_plugins enforces integer indices
@@ -1131,7 +1137,9 @@ def pad_to_size(array, padded_shape):
     ---------
     pad_to_oversample, pad_or_crop_to_shape
     """
-
+    global _ncp
+    from .accel_math import _ncp
+    
     if len(padded_shape) < 2:
         outsize0 = padded_shape
         outsize1 = padded_shape
@@ -1174,7 +1182,9 @@ def pad_or_crop_to_shape(array, target_shape):
     pad_to_oversample, pad_to_size
 
     """
-
+    global _ncp
+    from .accel_math import _ncp
+    
     if array.shape == target_shape:
         return array
 
@@ -1189,7 +1199,7 @@ def pad_or_crop_to_shape(array, target_shape):
         _log.debug("Array shape " + str(array.shape) + " is smaller than desired shape " + str(
             [lx_w, ly_w]) + "; will attempt to zero-pad the array")
 
-        resampled_array = np.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
+        resampled_array = _ncp.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
         resampled_array[border_x:border_x + lx, border_y:border_y + ly] = array
         _log.debug("  Padded with a {:d} x {:d} border to "
                    " match the desired shape".format(border_x, border_y))
@@ -1236,7 +1246,9 @@ def rebin_array(a=None, rc=(2, 2), verbose=False):
     anand@stsci.edu
 
     """
-
+    global _ncp
+    from .accel_math import _ncp
+    
     r, c = rc
 
     R = a.shape[0]
@@ -1254,7 +1266,7 @@ def rebin_array(a=None, rc=(2, 2), verbose=False):
             print("row loop")
         for ci in range(0, nc):
             Clo = ci * c
-            b[ri, ci] = np.add.reduce(a[Rlo:Rlo + r, Clo:Clo + c].copy().flat)
+            b[ri, ci] = _ncp.add.reduce(a[Rlo:Rlo + r, Clo:Clo + c].copy().flat)
             if verbose:
                 print("    [%d:%d, %d:%d]" % (Rlo, Rlo + r, Clo, Clo + c))
                 print("%4.0f" % np.add.reduce(a[Rlo:Rlo + r, Clo:Clo + c].copy().flat))

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -144,7 +144,7 @@ class ParameterizedWFE(WavefrontError):
     @utils.quantity_input(coefficients=u.meter, radius=u.meter)
     def __init__(self, name="Parameterized Distortion", coefficients=None, radius=1*u.meter,
                  basis_factory=None, **kwargs):
-        if not isinstance(basis_factory, collections.Callable):
+        if not isinstance(basis_factory, collections.abc.Callable):
             raise ValueError("'basis_factory' must be a callable that can "
                              "calculate basis functions")
         self.radius = radius

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -29,12 +29,6 @@ accel_math.update_math_settings()
 global _ncp
 from .accel_math import _ncp
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-# else:
-#     import numpy as np
-
 
 __all__ = ['WavefrontError', 'ParameterizedWFE', 'ZernikeWFE', 'SineWaveWFE',
         'StatisticalPSDWFE', 'PowerSpectrumWFE', 'KolmogorovWFE', 'ThermalBloomingWFE']
@@ -229,9 +223,6 @@ class ZernikeWFE(WavefrontError):
             scale, or a float giving the wavelength in meters
             for a temporary Wavefront used to compute the OPD.
         """
-        
-        print(_ncp)
-        
         # the Zernike optic, being normalized on a circle, is
         # implicitly also a circular aperture:
         aperture_intensity = self.circular_aperture.get_transmission(wave)

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -40,12 +40,6 @@ accel_math.update_math_settings()
 global _ncp
 from .accel_math import _ncp
 
-# import numpy
-# if accel_math._USE_CUPY:
-#     import cupy as np
-# else:
-#     import numpy as np
-
 from functools import lru_cache
 
 __all__ = [
@@ -255,9 +249,6 @@ def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
         raise ValueError("If you provide either the `theta` or `rho` input array, you must "
                          "provide both of them.")
         
-    print(type(rho), type(theta))
-    print(rho.shape, theta.shape)
-    print(rho.shape == theta.shape)
     if not _ncp.all(_ncp.asarray(rho.shape == theta.shape)):
         raise ValueError('The rho and theta arrays do not have consistent shape.')
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -84,7 +84,7 @@ def str_zernike(n, m):
     terms = []
     for k in range(int((n - m) / 2) + 1):
         coef = ((-1) ** k * factorial(n - k) /
-                (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
         if coef != 0:
             formatcode = "{0:d}" if k == 0 else "{0:+d}"
             terms.append((formatcode + " r^{1:d} ").format(int(coef), n - 2 * k))
@@ -171,7 +171,7 @@ def R(n, m, rho):
     else:
         for k in range(int((n - m) / 2) + 1):
             coef = ((-1) ** k * factorial(n - k) /
-                    (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                    (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
             output += coef * rho ** (n - 2 * k)
         return output
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     scipy>=1.5.0
     matplotlib>=3.2.0
     astropy>=4.0.0
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39}-test
-    py{37,38,39}-{astropydev,legacy,latest}-test
-    py{37,38,39}{,-syn}-cov
-    py38-numexpr-mkl-cov
+    py{38,39,310}-test
+    py{38,39,310}-{astropydev,legacy,latest}-test
+    py{38,39,310}{,-syn}-cov
+    py39-numexpr-mkl-cov
 
 [testenv]
 passenv = *
@@ -31,7 +31,7 @@ commands=
     cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
-basepython= python3.8
+basepython= python3.9
 deps=
     sphinx
     sphinx_rtd_theme
@@ -48,7 +48,7 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.8
+basepython= python3.9
 skip_install = true
 description = check package code style
 deps =


### PR DESCRIPTION
The previous CuPy implementation did not allow users to swap between CPU and GPU computations and had some issues with a few optical elements, so the implementation was changed from scratch to be more flexible. 

Now, accel_math sets whether numpy or cupy is used by setting _ncp to the package required based on the users conf settings. Critically, _ncp is updated when the user changes the conf settings without needing to restart a kernel. 

Similarly, accel_math sets and updates _scipy to either scipy or cupyx.scipy in order to use ndimage and special functions. 